### PR TITLE
Add base conversion web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Base Number Incrementer</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    .display { margin-top: 1rem; font-size: 1.2rem; }
+    button { margin: 0 0.5rem; }
+  </style>
+</head>
+<body>
+  <h1>Base Number Incrementer</h1>
+  <label for="baseInput">Base (2-30):</label>
+  <input type="number" id="baseInput" min="2" max="30" value="10">
+  <div class="display">
+    Value in base <span id="baseLabel">10</span>: <span id="baseNumber">0</span>
+  </div>
+  <div class="display">
+    Base 10 value: <span id="decimalNumber">0</span>
+  </div>
+  <button id="decrement">-</button>
+  <button id="increment">+</button>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,5 @@
 Hello and Welcome! This repository is used for collaborating with external AI agents to test code building and direction.
+
+## Base Number Web App
+
+Open `index.html` in a browser to experiment with numbers in different bases. Choose a base between 2 and 30, increment or decrement the value, and see both the representation in the selected base and the decimal equivalent.

--- a/script.js
+++ b/script.js
@@ -1,0 +1,37 @@
+(() => {
+  const baseInput = document.getElementById('baseInput');
+  const baseLabel = document.getElementById('baseLabel');
+  const baseNumber = document.getElementById('baseNumber');
+  const decimalNumber = document.getElementById('decimalNumber');
+  const incBtn = document.getElementById('increment');
+  const decBtn = document.getElementById('decrement');
+
+  let current = 0;
+  let base = parseInt(baseInput.value, 10);
+
+  function updateDisplay() {
+    baseLabel.textContent = base;
+    baseNumber.textContent = current.toString(base).toUpperCase();
+    decimalNumber.textContent = current.toString(10);
+  }
+
+  baseInput.addEventListener('change', () => {
+    let value = parseInt(baseInput.value, 10);
+    if (isNaN(value)) value = 10;
+    base = Math.min(30, Math.max(2, value));
+    baseInput.value = base;
+    updateDisplay();
+  });
+
+  incBtn.addEventListener('click', () => {
+    current += 1;
+    updateDisplay();
+  });
+
+  decBtn.addEventListener('click', () => {
+    current -= 1;
+    updateDisplay();
+  });
+
+  updateDisplay();
+})();


### PR DESCRIPTION
## Summary
- create simple web interface for exploring numbers in bases 2-30 with increment/decrement controls
- display selected base representation and base-10 equivalent using letters for digits beyond 9

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e11e8c248326ad9e32153d741c7c