### PR TITLE
Animate digits with piston-like boxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,25 @@
     }
     #baseNumber {
       font-size: 3rem;
-      min-width: 4rem;
+      display: flex;
+      justify-content: center;
+      gap: 0.5rem;
+      min-width: 0;
+    }
+    .digit {
+      width: 3rem;
+      height: 4rem;
+      border: 2px solid #000;
+      position: relative;
+      overflow: hidden;
+    }
+    .digit span {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      line-height: 4rem;
+      text-align: center;
+      transition: transform 0.3s ease;
     }
     #decimalDisplay {
       margin-top: 1rem;
@@ -44,7 +62,7 @@
   <input type="number" id="baseInput" min="2" max="30" value="10">
   <div class="controls">
     <button id="decrement">-</button>
-    <div id="baseNumber">0</div>
+    <div id="baseNumber"></div>
     <button id="increment">+</button>
   </div>
   <div id="decimalDisplay">Base 10: <span id="decimalNumber">0</span></div>

--- a/script.js
+++ b/script.js
@@ -8,11 +8,75 @@
   const resetBtn = document.getElementById('reset');
 
   let current = 0;
+  let previous = 0;
   let base = parseInt(baseInput.value, 10);
+  const digits = [];
+
+  function createDigit(value) {
+    const digit = document.createElement('div');
+    digit.className = 'digit';
+    digit.textContent = value;
+    return digit;
+  }
+
+  function ensureDigits(length) {
+    while (digits.length < length) {
+      const d = createDigit('0');
+      baseNumber.prepend(d);
+      digits.unshift(d);
+    }
+    while (digits.length > length) {
+      const d = digits.shift();
+      baseNumber.removeChild(d);
+    }
+  }
+
+  function animateDigit(elem, from, to, direction) {
+    elem.innerHTML = `<span class="old">${from}</span><span class="new">${to}</span>`;
+    const [oldSpan, newSpan] = elem.children;
+    if (direction === 'up') {
+      newSpan.style.transform = 'translateY(100%)';
+    } else {
+      newSpan.style.transform = 'translateY(-100%)';
+    }
+    // force reflow
+    void newSpan.offsetHeight;
+    if (direction === 'up') {
+      oldSpan.style.transform = 'translateY(-100%)';
+      newSpan.style.transform = 'translateY(0)';
+    } else {
+      oldSpan.style.transform = 'translateY(100%)';
+      newSpan.style.transform = 'translateY(0)';
+    }
+    oldSpan.addEventListener('transitionend', () => {
+      elem.textContent = to;
+    }, { once: true });
+  }
+
+  function updateDigits(prev, next) {
+    const prevStr = prev.toString(base).toUpperCase();
+    const nextStr = next.toString(base).toUpperCase();
+    const maxLen = Math.max(prevStr.length, nextStr.length);
+
+    ensureDigits(maxLen);
+
+    const paddedPrev = prevStr.padStart(maxLen, '0');
+    const paddedNext = nextStr.padStart(maxLen, '0');
+    const direction = next >= prev ? 'up' : 'down';
+
+    for (let i = 0; i < maxLen; i++) {
+      if (paddedPrev[i] !== paddedNext[i]) {
+        animateDigit(digits[i], paddedPrev[i], paddedNext[i], direction);
+      } else {
+        digits[i].textContent = paddedNext[i];
+      }
+    }
+  }
 
   function updateDisplay() {
-    baseNumber.textContent = current.toString(base).toUpperCase();
+    updateDigits(previous, current);
     decimalNumber.textContent = current.toString(10);
+    previous = current;
   }
 
   baseInput.addEventListener('change', () => {
@@ -24,21 +88,27 @@
   });
 
   incBtn.addEventListener('click', () => {
+    previous = current;
     current += 1;
     updateDisplay();
   });
 
   decBtn.addEventListener('click', () => {
-    current -= 1;
-    updateDisplay();
+    if (current > 0) {
+      previous = current;
+      current -= 1;
+      updateDisplay();
+    }
   });
 
   resetBtn.addEventListener('click', () => {
     base = 10;
     current = 0;
+    previous = 0;
     baseInput.value = base;
     updateDisplay();
   });
 
   updateDisplay();
 })();
+


### PR DESCRIPTION
## Summary
- Render each digit in its own styled box and animate transitions like an odometer
- Link digit updates so carries and borrows trigger neighboring digits
- Prevent decrementing below zero for smoother piston effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ed31c1388326970cd0c31e8ab890