### PR TITLE
Fix button increment and enlarge number display

### DIFF
--- a/script.js
+++ b/script.js
@@ -108,18 +108,23 @@
     }
   }
 
-  incBtn.addEventListener('click', inc);
-  decBtn.addEventListener('click', dec);
-
   function autoRepeat(btn, handler) {
     let interval;
-    const clear = () => interval && clearInterval(interval);
-    btn.addEventListener('mousedown', () => {
+    const start = () => {
       handler();
       interval = setInterval(handler, 150);
-    });
+    };
+    const clear = () => interval && clearInterval(interval);
+    btn.addEventListener('mousedown', start);
+    btn.addEventListener('touchstart', start);
     ['mouseup', 'mouseleave', 'touchend', 'touchcancel'].forEach(ev =>
       btn.addEventListener(ev, clear));
+    btn.addEventListener('keydown', e => {
+      if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault();
+        handler();
+      }
+    });
   }
 
   autoRepeat(incBtn, inc);

--- a/style.css
+++ b/style.css
@@ -70,6 +70,7 @@ body {
 .base-value {
   margin-top: 0.5rem;
   font-weight: 500;
+  font-size: 1.5rem;
 }
 
 .controls {
@@ -112,8 +113,8 @@ button:focus-visible {
 }
 
 .digit {
-  width: 3rem;
-  height: 4rem;
+    width: 4rem;
+    height: 5rem;
   border: 1px solid var(--card-border);
   border-radius: 0.5rem;
   background: #fff;
@@ -123,7 +124,7 @@ button:focus-visible {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 2.5rem;
+    font-size: 3.5rem;
   font-variant-numeric: tabular-nums;
 }
 
@@ -146,9 +147,9 @@ button:focus-visible {
 }
 
 #decimalDisplay {
-  font-size: 1rem;
-  color: var(--muted);
-}
+    font-size: 1.5rem;
+    color: var(--muted);
+  }
 
 .reset {
   margin-top: 2rem;


### PR DESCRIPTION
## Summary
- Avoid double increments by consolidating auto-repeat logic and removing duplicate click handlers
- Enlarge displayed digits and decimal/base values for better readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cb2f5bf88326bed33bb3a9e51124