### PR TITLE
feat: add split-flap animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,11 +1,11 @@
 (() => {
-  const baseSlider = document.getElementById('baseSlider');
-  const baseValue = document.getElementById('baseValue');
-  const baseNumber = document.getElementById('baseNumber');
-  const decimalNumber = document.getElementById('decimalNumber');
-  const incBtn = document.getElementById('increment');
-  const decBtn = document.getElementById('decrement');
-  const resetBtn = document.getElementById('reset');
+  const baseSlider = document.getElementById("baseSlider");
+  const baseValue = document.getElementById("baseValue");
+  const baseNumber = document.getElementById("baseNumber");
+  const decimalNumber = document.getElementById("decimalNumber");
+  const incBtn = document.getElementById("increment");
+  const decBtn = document.getElementById("decrement");
+  const resetBtn = document.getElementById("reset");
 
   let current = 0;
   let previous = 0;
@@ -13,15 +13,15 @@
   const digits = [];
 
   function createDigit(value) {
-    const digit = document.createElement('div');
-    digit.className = 'digit';
+    const digit = document.createElement("div");
+    digit.className = "digit";
     digit.textContent = value;
     return digit;
   }
 
   function ensureDigits(length) {
     while (digits.length < length) {
-      const d = createDigit('0');
+      const d = createDigit("0");
       baseNumber.prepend(d);
       digits.unshift(d);
     }
@@ -32,26 +32,18 @@
   }
 
   function animateDigit(elem, from, to, direction) {
-    return new Promise(resolve => {
-      elem.innerHTML = `<span class="old">${from}</span><span class="new">${to}</span>`;
-      const [oldSpan, newSpan] = elem.children;
-      if (direction === 'up') {
-        newSpan.style.transform = 'translateY(100%)';
-      } else {
-        newSpan.style.transform = 'translateY(-100%)';
-      }
-      void newSpan.offsetHeight; // force reflow
-      if (direction === 'up') {
-        oldSpan.style.transform = 'translateY(-100%)';
-        newSpan.style.transform = 'translateY(0)';
-      } else {
-        oldSpan.style.transform = 'translateY(100%)';
-        newSpan.style.transform = 'translateY(0)';
-      }
-      oldSpan.addEventListener('transitionend', () => {
+    return new Promise((resolve) => {
+      elem.innerHTML = `<span class="front">${from}</span><span class="back">${to}</span>`;
+      const className = direction === "up" ? "flip-up" : "flip-down";
+      elem.classList.add(className);
+      const onEnd = () => {
+        elem.classList.remove(className);
         elem.textContent = to;
         resolve();
-      }, { once: true });
+      };
+      elem
+        .querySelector(".back")
+        .addEventListener("animationend", onEnd, { once: true });
     });
   }
 
@@ -62,9 +54,9 @@
 
     ensureDigits(maxLen);
 
-    const paddedPrev = prevStr.padStart(maxLen, '0');
-    const paddedNext = nextStr.padStart(maxLen, '0');
-    const direction = next >= prev ? 'up' : 'down';
+    const paddedPrev = prevStr.padStart(maxLen, "0");
+    const paddedNext = nextStr.padStart(maxLen, "0");
+    const direction = next >= prev ? "up" : "down";
 
     const changed = [];
     for (let i = maxLen - 1; i >= 0; i--) {
@@ -87,11 +79,11 @@
     previous = current;
   }
 
-  baseSlider.addEventListener('input', () => {
+  baseSlider.addEventListener("input", () => {
     base = parseInt(baseSlider.value, 10);
     updateDisplay();
-    baseNumber.classList.add('highlight');
-    setTimeout(() => baseNumber.classList.remove('highlight'), 300);
+    baseNumber.classList.add("highlight");
+    setTimeout(() => baseNumber.classList.remove("highlight"), 300);
   });
 
   function inc() {
@@ -115,12 +107,13 @@
       interval = setInterval(handler, 150);
     };
     const clear = () => interval && clearInterval(interval);
-    btn.addEventListener('mousedown', start);
-    btn.addEventListener('touchstart', start);
-    ['mouseup', 'mouseleave', 'touchend', 'touchcancel'].forEach(ev =>
-      btn.addEventListener(ev, clear));
-    btn.addEventListener('keydown', e => {
-      if (e.key === ' ' || e.key === 'Enter') {
+    btn.addEventListener("mousedown", start);
+    btn.addEventListener("touchstart", start);
+    ["mouseup", "mouseleave", "touchend", "touchcancel"].forEach((ev) =>
+      btn.addEventListener(ev, clear),
+    );
+    btn.addEventListener("keydown", (e) => {
+      if (e.key === " " || e.key === "Enter") {
         e.preventDefault();
         handler();
       }
@@ -130,7 +123,7 @@
   autoRepeat(incBtn, inc);
   autoRepeat(decBtn, dec);
 
-  resetBtn.addEventListener('click', () => {
+  resetBtn.addEventListener("click", () => {
     base = 10;
     current = 0;
     previous = 0;
@@ -138,10 +131,10 @@
     updateDisplay();
   });
 
-  document.addEventListener('keydown', e => {
-    if (e.key === 'ArrowUp') {
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "ArrowUp") {
       inc();
-    } else if (e.key === 'ArrowDown') {
+    } else if (e.key === "ArrowDown") {
       dec();
     }
   });

--- a/style.css
+++ b/style.css
@@ -20,7 +20,7 @@
 }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: "Inter", sans-serif;
   background: var(--bg);
   color: var(--text);
   margin: 0;
@@ -93,7 +93,9 @@ button {
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 button:active {
@@ -113,24 +115,35 @@ button:focus-visible {
 }
 
 .digit {
-    width: 4rem;
-    height: 5rem;
+  width: 4rem;
+  height: 5rem;
   border: 1px solid var(--card-border);
-  border-radius: 0.5rem;
-  background: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border-radius: 0.25rem;
+  background: #111;
+  color: #fff;
   position: relative;
   overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
-    font-size: 3.5rem;
+  font-size: 3.5rem;
   font-variant-numeric: tabular-nums;
+  perspective: 600px;
+}
+
+.digit::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  background: var(--card-border);
 }
 
 @media (prefers-color-scheme: dark) {
   .digit {
-    background: #2f2f2f;
+    background: #000;
   }
 }
 
@@ -143,13 +156,69 @@ button:focus-visible {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.3s ease;
+  backface-visibility: hidden;
+}
+
+.digit .back {
+  transform: rotateX(180deg);
+}
+
+.digit.flip-up .front {
+  animation: flip-up-front 0.5s forwards;
+}
+
+.digit.flip-up .back {
+  animation: flip-up-back 0.5s forwards;
+}
+
+.digit.flip-down .front {
+  animation: flip-down-front 0.5s forwards;
+}
+
+.digit.flip-down .back {
+  animation: flip-down-back 0.5s forwards;
+}
+
+@keyframes flip-up-front {
+  from {
+    transform: rotateX(0deg);
+  }
+  to {
+    transform: rotateX(-180deg);
+  }
+}
+
+@keyframes flip-up-back {
+  from {
+    transform: rotateX(180deg);
+  }
+  to {
+    transform: rotateX(0deg);
+  }
+}
+
+@keyframes flip-down-front {
+  from {
+    transform: rotateX(0deg);
+  }
+  to {
+    transform: rotateX(180deg);
+  }
+}
+
+@keyframes flip-down-back {
+  from {
+    transform: rotateX(-180deg);
+  }
+  to {
+    transform: rotateX(0deg);
+  }
 }
 
 #decimalDisplay {
-    font-size: 1.5rem;
-    color: var(--muted);
-  }
+  font-size: 1.5rem;
+  color: var(--muted);
+}
 
 .reset {
   margin-top: 2rem;


### PR DESCRIPTION
## Summary
- add 3D flip animation to update digits, mimicking split-flap mechanics
- restyle digit display with dark panels and center divider

## Testing
- `node --check script.js && echo 'syntax OK'`
- `npx prettier --check script.js style.css`
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cc7a4c748326b3f7b22d6e2cd1f8