### PR TITLE
Add dynamic bit-length option for number display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,42 +1,75 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Base Number Incrementer</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css">
-</head>
-<body>
-  <main class="card" role="main">
-    <h1>Base Incrementer</h1>
-    <p class="subtitle">Explore numbers in different bases.</p>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Base Number Incrementer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="card" role="main">
+      <h1>Base Incrementer</h1>
+      <p class="subtitle">Explore numbers in different bases.</p>
 
-    <div class="base-control">
-      <label for="baseSlider">Base</label>
-      <div class="slider-wrapper">
-        <span class="min">2</span>
-        <input type="range" id="baseSlider" min="2" max="30" value="10" aria-label="select base" />
-        <span class="max">30</span>
+      <div class="bits-control">
+        <label for="bitsSlider">Bits</label>
+        <div class="slider-wrapper">
+          <span class="min">1</span>
+          <input
+            type="range"
+            id="bitsSlider"
+            min="1"
+            max="16"
+            value="8"
+            aria-label="select bits"
+          />
+          <span class="max">16</span>
+        </div>
+        <div id="bitsValue" class="bits-value" aria-live="polite">8</div>
+        <label class="dynamic-toggle">
+          <input type="checkbox" id="dynamicBits" />
+          Dynamic bits
+        </label>
       </div>
-      <div id="baseValue" class="base-value" aria-live="polite">10</div>
-    </div>
 
-    <div class="controls">
-      <button id="decrement" aria-label="decrease">
-        <span aria-hidden="true">−</span>
-      </button>
-      <div id="baseNumber" class="display" aria-live="polite"></div>
-      <button id="increment" aria-label="increase">
-        <span aria-hidden="true">+</span>
-      </button>
-    </div>
+      <div class="base-control">
+        <label for="baseSlider">Base</label>
+        <div class="slider-wrapper">
+          <span class="min">2</span>
+          <input
+            type="range"
+            id="baseSlider"
+            min="2"
+            max="30"
+            value="10"
+            aria-label="select base"
+          />
+          <span class="max">30</span>
+        </div>
+        <div id="baseValue" class="base-value" aria-live="polite">10</div>
+      </div>
 
-    <div id="decimalDisplay" aria-live="polite">Decimal: <span id="decimalNumber">0</span></div>
+      <div class="controls">
+        <button id="decrement" aria-label="decrease">
+          <span aria-hidden="true">−</span>
+        </button>
+        <div id="baseNumber" class="display" aria-live="polite"></div>
+        <button id="increment" aria-label="increase">
+          <span aria-hidden="true">+</span>
+        </button>
+      </div>
 
-    <button id="reset" class="reset">Reset</button>
-  </main>
-  <script src="script.js"></script>
-</body>
+      <div id="decimalDisplay" aria-live="polite">
+        Decimal: <span id="decimalNumber">0</span>
+      </div>
+
+      <button id="reset" class="reset">Reset</button>
+    </main>
+    <script src="script.js"></script>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,27 +1,40 @@
 (() => {
-  const baseSlider = document.getElementById('baseSlider');
-  const baseValue = document.getElementById('baseValue');
-  const baseNumber = document.getElementById('baseNumber');
-  const decimalNumber = document.getElementById('decimalNumber');
-  const incBtn = document.getElementById('increment');
-  const decBtn = document.getElementById('decrement');
-  const resetBtn = document.getElementById('reset');
+  const baseSlider = document.getElementById("baseSlider");
+  const baseValue = document.getElementById("baseValue");
+  const bitsSlider = document.getElementById("bitsSlider");
+  const bitsValue = document.getElementById("bitsValue");
+  const dynamicBits = document.getElementById("dynamicBits");
+  const baseNumber = document.getElementById("baseNumber");
+  const decimalNumber = document.getElementById("decimalNumber");
+  const incBtn = document.getElementById("increment");
+  const decBtn = document.getElementById("decrement");
+  const resetBtn = document.getElementById("reset");
 
   let current = 0;
   let previous = 0;
   let base = parseInt(baseSlider.value, 10);
+  let bits = parseInt(bitsSlider.value, 10);
+  let dynamic = false;
   const digits = [];
 
+  function maxValue() {
+    return 2 ** bits - 1;
+  }
+
+  function currentBits() {
+    return Math.max(1, current.toString(2).length);
+  }
+
   function createDigit(value) {
-    const digit = document.createElement('div');
-    digit.className = 'digit';
+    const digit = document.createElement("div");
+    digit.className = "digit";
     digit.textContent = value;
     return digit;
   }
 
   function ensureDigits(length) {
     while (digits.length < length) {
-      const d = createDigit('0');
+      const d = createDigit("0");
       baseNumber.prepend(d);
       digits.unshift(d);
     }
@@ -32,39 +45,46 @@
   }
 
   function animateDigit(elem, from, to, direction) {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       elem.innerHTML = `<span class="old">${from}</span><span class="new">${to}</span>`;
       const [oldSpan, newSpan] = elem.children;
-      if (direction === 'up') {
-        newSpan.style.transform = 'translateY(100%)';
+      if (direction === "up") {
+        newSpan.style.transform = "translateY(100%)";
       } else {
-        newSpan.style.transform = 'translateY(-100%)';
+        newSpan.style.transform = "translateY(-100%)";
       }
       void newSpan.offsetHeight; // force reflow
-      if (direction === 'up') {
-        oldSpan.style.transform = 'translateY(-100%)';
-        newSpan.style.transform = 'translateY(0)';
+      if (direction === "up") {
+        oldSpan.style.transform = "translateY(-100%)";
+        newSpan.style.transform = "translateY(0)";
       } else {
-        oldSpan.style.transform = 'translateY(100%)';
-        newSpan.style.transform = 'translateY(0)';
+        oldSpan.style.transform = "translateY(100%)";
+        newSpan.style.transform = "translateY(0)";
       }
-      oldSpan.addEventListener('transitionend', () => {
-        elem.textContent = to;
-        resolve();
-      }, { once: true });
+      oldSpan.addEventListener(
+        "transitionend",
+        () => {
+          elem.textContent = to;
+          resolve();
+        },
+        { once: true },
+      );
     });
   }
 
   async function updateDigits(prev, next) {
     const prevStr = prev.toString(base).toUpperCase();
     const nextStr = next.toString(base).toUpperCase();
-    const maxLen = Math.max(prevStr.length, nextStr.length);
+    const targetLen = dynamic
+      ? Math.max(nextStr.length, 1)
+      : maxValue().toString(base).length;
+    const maxLen = dynamic ? Math.max(prevStr.length, targetLen) : targetLen;
 
     ensureDigits(maxLen);
 
-    const paddedPrev = prevStr.padStart(maxLen, '0');
-    const paddedNext = nextStr.padStart(maxLen, '0');
-    const direction = next >= prev ? 'up' : 'down';
+    const paddedPrev = prevStr.padStart(maxLen, "0");
+    const paddedNext = nextStr.padStart(maxLen, "0");
+    const direction = next >= prev ? "up" : "down";
 
     const changed = [];
     for (let i = maxLen - 1; i >= 0; i--) {
@@ -78,34 +98,72 @@
     for (const i of changed) {
       await animateDigit(digits[i], paddedPrev[i], paddedNext[i], direction);
     }
+
+    if (dynamic) {
+      ensureDigits(targetLen);
+    }
   }
 
   async function updateDisplay() {
     await updateDigits(previous, current);
     decimalNumber.textContent = current.toString(10);
     baseValue.textContent = base;
+    bitsValue.textContent = dynamic ? currentBits() : bits;
     previous = current;
   }
 
-  baseSlider.addEventListener('input', () => {
+  baseSlider.addEventListener("input", () => {
     base = parseInt(baseSlider.value, 10);
     updateDisplay();
-    baseNumber.classList.add('highlight');
-    setTimeout(() => baseNumber.classList.remove('highlight'), 300);
+    baseNumber.classList.add("highlight");
+    setTimeout(() => baseNumber.classList.remove("highlight"), 300);
+  });
+
+  bitsSlider.addEventListener("input", () => {
+    bits = parseInt(bitsSlider.value, 10);
+    const max = maxValue();
+    if (current > max) {
+      current = max;
+    }
+    previous = current;
+    updateDisplay();
+    baseNumber.classList.add("highlight");
+    setTimeout(() => baseNumber.classList.remove("highlight"), 300);
+  });
+
+  dynamicBits.addEventListener("change", () => {
+    dynamic = dynamicBits.checked;
+    bitsSlider.disabled = dynamic;
+    if (!dynamic) {
+      const max = maxValue();
+      if (current > max) {
+        previous = current;
+        current = max;
+      }
+    }
+    updateDisplay();
   });
 
   function inc() {
     previous = current;
-    current += 1;
+    if (dynamic) {
+      current += 1;
+    } else {
+      const max = maxValue();
+      current = (current + 1) % (max + 1);
+    }
     updateDisplay();
   }
 
   function dec() {
-    if (current > 0) {
-      previous = current;
-      current -= 1;
-      updateDisplay();
+    previous = current;
+    if (dynamic) {
+      current = Math.max(0, current - 1);
+    } else {
+      const max = maxValue();
+      current = (current - 1 + (max + 1)) % (max + 1);
     }
+    updateDisplay();
   }
 
   function autoRepeat(btn, handler) {
@@ -115,12 +173,13 @@
       interval = setInterval(handler, 150);
     };
     const clear = () => interval && clearInterval(interval);
-    btn.addEventListener('mousedown', start);
-    btn.addEventListener('touchstart', start);
-    ['mouseup', 'mouseleave', 'touchend', 'touchcancel'].forEach(ev =>
-      btn.addEventListener(ev, clear));
-    btn.addEventListener('keydown', e => {
-      if (e.key === ' ' || e.key === 'Enter') {
+    btn.addEventListener("mousedown", start);
+    btn.addEventListener("touchstart", start);
+    ["mouseup", "mouseleave", "touchend", "touchcancel"].forEach((ev) =>
+      btn.addEventListener(ev, clear),
+    );
+    btn.addEventListener("keydown", (e) => {
+      if (e.key === " " || e.key === "Enter") {
         e.preventDefault();
         handler();
       }
@@ -130,18 +189,23 @@
   autoRepeat(incBtn, inc);
   autoRepeat(decBtn, dec);
 
-  resetBtn.addEventListener('click', () => {
+  resetBtn.addEventListener("click", () => {
     base = 10;
+    bits = 8;
     current = 0;
     previous = 0;
     baseSlider.value = base;
+    bitsSlider.value = bits;
+    dynamic = false;
+    dynamicBits.checked = false;
+    bitsSlider.disabled = false;
     updateDisplay();
   });
 
-  document.addEventListener('keydown', e => {
-    if (e.key === 'ArrowUp') {
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "ArrowUp") {
       inc();
-    } else if (e.key === 'ArrowDown') {
+    } else if (e.key === "ArrowDown") {
       dec();
     }
   });

--- a/style.css
+++ b/style.css
@@ -20,7 +20,7 @@
 }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: "Inter", sans-serif;
   background: var(--bg);
   color: var(--text);
   margin: 0;
@@ -50,6 +50,10 @@ body {
   margin-bottom: 1.5rem;
 }
 
+.bits-control {
+  margin-bottom: 1.5rem;
+}
+
 .slider-wrapper {
   display: flex;
   align-items: center;
@@ -67,10 +71,35 @@ body {
   accent-color: var(--accent);
 }
 
+#bitsSlider {
+  flex: 1;
+  accent-color: var(--accent);
+}
+
 .base-value {
   margin-top: 0.5rem;
   font-weight: 500;
   font-size: 1.5rem;
+}
+
+.bits-value {
+  margin-top: 0.5rem;
+  font-weight: 500;
+  font-size: 1.5rem;
+}
+
+.dynamic-toggle {
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+.dynamic-toggle input {
+  accent-color: var(--accent);
 }
 
 .controls {
@@ -93,7 +122,9 @@ button {
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 button:active {
@@ -113,8 +144,8 @@ button:focus-visible {
 }
 
 .digit {
-    width: 4rem;
-    height: 5rem;
+  width: 4rem;
+  height: 5rem;
   border: 1px solid var(--card-border);
   border-radius: 0.5rem;
   background: #fff;
@@ -124,7 +155,7 @@ button:focus-visible {
   display: flex;
   align-items: center;
   justify-content: center;
-    font-size: 3.5rem;
+  font-size: 3.5rem;
   font-variant-numeric: tabular-nums;
 }
 
@@ -147,9 +178,9 @@ button:focus-visible {
 }
 
 #decimalDisplay {
-    font-size: 1.5rem;
-    color: var(--muted);
-  }
+  font-size: 1.5rem;
+  color: var(--muted);
+}
 
 .reset {
   margin-top: 2rem;


### PR DESCRIPTION
## Summary
- add checkbox to enable dynamic bit-width that grows with the number
- disable fixed bit slider and compute current bits automatically
- adjust increment/decrement and digit rendering to expand or shrink as needed

## Testing
- `node --check script.js`
- `npx -y prettier --check index.html style.css script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3676e0c808326ab8ef14e0838e26e