### PR TITLE
Add binary display tester page

### DIFF
--- a/display.html
+++ b/display.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Binary Display Tester</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="card" role="main">
+    <h1>Binary Display</h1>
+    <div class="display-controls">
+      <label>Width <input type="number" id="width" min="1" max="256" value="8"></label>
+      <label>Height <input type="number" id="height" min="1" max="256" value="8"></label>
+      <button id="render">Render</button>
+    </div>
+    <textarea id="bitmap" placeholder="Paste your bitmap using 0s and 1s"></textarea>
+    <div id="error" class="error" aria-live="polite"></div>
+    <div id="grid"></div>
+  </main>
+  <script src="display.js"></script>
+</body>
+</html>

--- a/display.js
+++ b/display.js
@@ -1,0 +1,41 @@
+(() => {
+  const widthInput = document.getElementById('width');
+  const heightInput = document.getElementById('height');
+  const bitmapInput = document.getElementById('bitmap');
+  const renderBtn = document.getElementById('render');
+  const grid = document.getElementById('grid');
+  const error = document.getElementById('error');
+
+  function render() {
+    const w = Math.min(Math.max(parseInt(widthInput.value, 10) || 1, 1), 256);
+    const h = Math.min(Math.max(parseInt(heightInput.value, 10) || 1, 1), 256);
+    const bits = bitmapInput.value.replace(/[^01]/g, '');
+    const needed = w * h;
+
+    if (bits.length < needed) {
+      error.textContent = `Provided ${bits.length} bits, but ${needed} required. Missing bits are assumed 0.`;
+    } else if (bits.length > needed) {
+      error.textContent = `Provided ${bits.length} bits, but ${needed} required. Extra bits will be ignored.`;
+    } else {
+      error.textContent = '';
+    }
+
+    const normalized = bits.padEnd(needed, '0').slice(0, needed);
+    grid.innerHTML = '';
+
+    const cellSize = Math.floor(512 / Math.max(w, h));
+    grid.style.gridTemplateColumns = `repeat(${w}, 1fr)`;
+    grid.style.gridTemplateRows = `repeat(${h}, 1fr)`;
+    grid.style.width = `${cellSize * w}px`;
+    grid.style.height = `${cellSize * h}px`;
+
+    for (let i = 0; i < needed; i++) {
+      const cell = document.createElement('div');
+      cell.className = 'pixel';
+      cell.style.background = normalized[i] === '1' ? '#000' : '#fff';
+      grid.appendChild(cell);
+    }
+  }
+
+  renderBtn.addEventListener('click', render);
+})();

--- a/readme.md
+++ b/readme.md
@@ -3,3 +3,7 @@ Hello and Welcome! This repository is used for collaborating with external AI ag
 ## Base Number Web App
 
 Open `index.html` in a browser to experiment with numbers in different bases. Choose a base between 2 and 30, then use the large `-` and `+` buttons beside the centered value to decrement or increment it. The base-specific value is displayed prominently with the base‑10 equivalent shown beneath it.
+
+## Binary Display Tester
+
+Open `display.html` to experiment with controlling a pixel display via binary. Select a width and height between 1 and 256, paste a bitmap of `0`s and `1`s, and render it to visualize the pixels.

--- a/style.css
+++ b/style.css
@@ -180,3 +180,34 @@ button:focus-visible {
     width: 100%;
   }
 }
+
+.display-controls {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+#bitmap {
+  width: 100%;
+  min-height: 6rem;
+  margin-top: 1rem;
+  font-family: monospace;
+}
+
+#error {
+  color: var(--accent);
+  margin-top: 0.5rem;
+}
+
+#grid {
+  display: grid;
+  margin-top: 1rem;
+  border: 1px solid var(--card-border);
+}
+
+.pixel {
+  box-sizing: border-box;
+  border: 1px solid var(--card-border);
+}


### PR DESCRIPTION
## Summary
- Add a new Binary Display page for experimenting with bitmap rendering
- Implement bitmap parsing and grid rendering logic in JavaScript
- Style the display controls, textarea, and pixel grid; update README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acd47c682083269ad06f4dd063c1eb