### PR TITLE
Add RGB toggle and correct binary display mapping

### DIFF
--- a/display.html
+++ b/display.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Binary Display Tester</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="card" role="main">
+    <h1>Binary Display</h1>
+    <div class="display-controls">
+      <label>Width <input type="number" id="width" min="1" max="256" value="8"></label>
+      <label>Height <input type="number" id="height" min="1" max="256" value="8"></label>
+      <label>Mode
+        <select id="mode">
+          <option value="bw">1-bit B/W</option>
+          <option value="rgb">24-bit RGB</option>
+        </select>
+      </label>
+      <button id="render">Render</button>
+    </div>
+    <textarea id="bitmap" placeholder="Paste your bitmap using 0s and 1s (RGB mode uses 24 bits per pixel)"></textarea>
+    <div id="error" class="error" aria-live="polite"></div>
+    <div id="grid"></div>
+  </main>
+  <script src="display.js"></script>
+</body>
+</html>

--- a/display.js
+++ b/display.js
@@ -1,0 +1,52 @@
+(() => {
+  const widthInput = document.getElementById('width');
+  const heightInput = document.getElementById('height');
+  const bitmapInput = document.getElementById('bitmap');
+  const renderBtn = document.getElementById('render');
+  const grid = document.getElementById('grid');
+  const error = document.getElementById('error');
+  const modeSelect = document.getElementById('mode');
+
+  function render() {
+    const w = Math.min(Math.max(parseInt(widthInput.value, 10) || 1, 1), 256);
+    const h = Math.min(Math.max(parseInt(heightInput.value, 10) || 1, 1), 256);
+    const bits = bitmapInput.value.replace(/[^01]/g, '');
+    const pixels = w * h;
+    const mode = modeSelect.value;
+    const bitsNeeded = mode === 'rgb' ? pixels * 24 : pixels;
+
+    if (bits.length < bitsNeeded) {
+      error.textContent = `Provided ${bits.length} bits, but ${bitsNeeded} required. Missing bits are assumed 0.`;
+    } else if (bits.length > bitsNeeded) {
+      error.textContent = `Provided ${bits.length} bits, but ${bitsNeeded} required. Extra bits will be ignored.`;
+    } else {
+      error.textContent = '';
+    }
+
+    const normalized = bits.padEnd(bitsNeeded, '0').slice(0, bitsNeeded);
+    grid.innerHTML = '';
+
+    const cellSize = Math.floor(512 / Math.max(w, h));
+    grid.style.gridTemplateColumns = `repeat(${w}, 1fr)`;
+    grid.style.gridTemplateRows = `repeat(${h}, 1fr)`;
+    grid.style.width = `${cellSize * w}px`;
+    grid.style.height = `${cellSize * h}px`;
+
+    for (let i = 0; i < pixels; i++) {
+      const cell = document.createElement('div');
+      cell.className = 'pixel';
+      if (mode === 'rgb') {
+        const offset = i * 24;
+        const r = parseInt(normalized.slice(offset, offset + 8), 2);
+        const g = parseInt(normalized.slice(offset + 8, offset + 16), 2);
+        const b = parseInt(normalized.slice(offset + 16, offset + 24), 2);
+        cell.style.background = `rgb(${r}, ${g}, ${b})`;
+      } else {
+        cell.style.background = normalized[i] === '1' ? '#fff' : '#000';
+      }
+      grid.appendChild(cell);
+    }
+  }
+
+  renderBtn.addEventListener('click', render);
+})();

--- a/readme.md
+++ b/readme.md
@@ -3,3 +3,7 @@ Hello and Welcome! This repository is used for collaborating with external AI ag
 ## Base Number Web App
 
 Open `index.html` in a browser to experiment with numbers in different bases. Choose a base between 2 and 30, then use the large `-` and `+` buttons beside the centered value to decrement or increment it. The base-specific value is displayed prominently with the base‑10 equivalent shown beneath it.
+
+## Binary Display Tester
+
+Open `display.html` to experiment with controlling a pixel display via binary. Select a width and height between 1 and 256, choose between 1-bit black/white and 24-bit RGB modes, then paste a bitmap of `0`s and `1`s (where `1` is on/white and `0` is off/black) to render the pixels. In RGB mode, provide 24 bits per pixel.

--- a/style.css
+++ b/style.css
@@ -180,3 +180,40 @@ button:focus-visible {
     width: 100%;
   }
 }
+
+.display-controls {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.display-controls label {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+#bitmap {
+  width: 100%;
+  min-height: 6rem;
+  margin-top: 1rem;
+  font-family: monospace;
+}
+
+#error {
+  color: var(--accent);
+  margin-top: 0.5rem;
+}
+
+#grid {
+  display: grid;
+  margin-top: 1rem;
+  border: 1px solid var(--card-border);
+}
+
+.pixel {
+  box-sizing: border-box;
+  border: 1px solid var(--card-border);
+}


### PR DESCRIPTION
## Summary
- Allow switching between 1-bit and 24-bit RGB bitmap modes
- Parse 24-bit color values and render RGB pixels
- Map `1` to white (on) and `0` to black (off)
- Style control labels and update README instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acd47c682083269ad06f4dd063c1eb