### PR TITLE
Fix render button text overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -96,6 +96,13 @@ button {
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
+#render {
+  width: auto;
+  height: auto;
+  font-size: 1rem;
+  padding: 0.5rem 1rem;
+}
+
 button:active {
   transform: scale(0.95);
 }


### PR DESCRIPTION
## Summary
- Resize render button to fit its text content

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acd9c83de083269d094cba82f7dc71